### PR TITLE
fix: read package version from pyproject

### DIFF
--- a/src/vetlog_calendar/__init__.py
+++ b/src/vetlog_calendar/__init__.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 import tomllib
 
@@ -21,9 +22,12 @@ __project__ = "vetlog-calendar"
 
 
 def _read_version() -> str:
-    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
-    with pyproject_path.open("rb") as pyproject_file:
-        return tomllib.load(pyproject_file)["project"]["version"]
+    try:
+        return version("py-vetlog-calendar")
+    except PackageNotFoundError:
+        pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        with pyproject_path.open("rb") as pyproject_file:
+            return tomllib.load(pyproject_file)["project"]["version"]
 
 
 __version__ = _read_version()

--- a/src/vetlog_calendar/__init__.py
+++ b/src/vetlog_calendar/__init__.py
@@ -12,6 +12,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from pathlib import Path
+import tomllib
+
+
 # Get project info from pyproject.toml
 __project__ = "vetlog-calendar"
-__version__ = "1.0.2"
+
+
+def _read_version() -> str:
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with pyproject_path.open("rb") as pyproject_file:
+        return tomllib.load(pyproject_file)["project"]["version"]
+
+
+__version__ = _read_version()

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,7 +1,8 @@
 import tomllib
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
-from vetlog_calendar import __version__
+from vetlog_calendar import __version__, _read_version
 from vetlog_calendar.main import version_check
 
 
@@ -11,6 +12,16 @@ def test_package_version_matches_pyproject():
         expected_version = tomllib.load(pyproject_file)["project"]["version"]
 
     assert __version__ == expected_version
+
+
+def test_read_version_falls_back_to_pyproject_when_package_metadata_is_missing(monkeypatch):
+    monkeypatch.setattr("vetlog_calendar.version", lambda _: (_ for _ in ()).throw(PackageNotFoundError()))
+
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with pyproject_path.open("rb") as pyproject_file:
+        expected_version = tomllib.load(pyproject_file)["project"]["version"]
+
+    assert _read_version() == expected_version
 
 
 def test_version_check_uses_pyproject_version(capsys):

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,19 @@
+import tomllib
+from pathlib import Path
+
+from vetlog_calendar import __version__
+from vetlog_calendar.main import version_check
+
+
+def test_package_version_matches_pyproject():
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    with pyproject_path.open("rb") as pyproject_file:
+        expected_version = tomllib.load(pyproject_file)["project"]["version"]
+
+    assert __version__ == expected_version
+
+
+def test_version_check_uses_pyproject_version(capsys):
+    version_check()
+
+    assert capsys.readouterr().out.strip() == f"vetlog-calendar version {__version__}"


### PR DESCRIPTION
Fixes #18

## Summary
- load `vetlog_calendar.__version__` from `pyproject.toml` instead of hardcoding it
- add tests to verify the package version and `uv run version` output stay in sync with `pyproject.toml`

## Testing
- pytest -q tests/unit/test_version.py tests/unit/test_config.py tests/unit/test_database.py