### PR TITLE
feat: add message when no new vaccinations found

### DIFF
--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -95,6 +95,13 @@ def list_vaccinations(
         pet_repository = PetRepository(session)
         user_repository = UserRepository(session)
         vaccinations = service.get_pending_vaccinations()
+        
+        # Print message if no new vaccinations found
+        if not vaccinations:
+            message = "No new vaccinations were found" if language == "en" else "No se encontraron nuevas vacunaciones"
+            print(message)
+            return
+        
         for vaccination in vaccinations:
             pet = pet_repository.find_by_id(vaccination.pet_id)
 

--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -95,13 +95,17 @@ def list_vaccinations(
         pet_repository = PetRepository(session)
         user_repository = UserRepository(session)
         vaccinations = service.get_pending_vaccinations()
-        
+
         # Print message if no new vaccinations found
         if not vaccinations:
-            message = "No new vaccinations were found" if language == "en" else "No se encontraron nuevas vacunaciones"
+            message = (
+                "No se encontraron nuevas vacunaciones"
+                if language == "es"
+                else "No new vaccinations were found"
+            )
             print(message)
             return
-        
+
         for vaccination in vaccinations:
             pet = pet_repository.find_by_id(vaccination.pet_id)
 


### PR DESCRIPTION
## Description
This PR adds a message output when there are no new vaccinations to process, so users know the command executed successfully but found nothing to process.

## Changes
- Added message output when vaccinations list is empty
- Support for both English and Spanish languages
- Early return to avoid unnecessary processing

## Related Issue
Closes #64

## Testing
- Manually tested with empty database
- Verified message appears in both languages