### PR TITLE
Add message when no new vaccinations are found

### DIFF
--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -92,9 +92,17 @@ def list_vaccinations(
         if service is None:
             repo = VaccinationRepository(session)
             service = VaccinationService(repo)
+
+        vaccinations = service.get_pending_vaccinations()
+
+        # If there are no pending vaccinations, print a message and exit
+        if not vaccinations:
+            print("no new vaccinations were found")
+            return
+
         pet_repository = PetRepository(session)
         user_repository = UserRepository(session)
-        vaccinations = service.get_pending_vaccinations()
+
         for vaccination in vaccinations:
             pet = pet_repository.find_by_id(vaccination.pet_id)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -129,6 +129,28 @@ def test_list_vaccinations(capsys, mock_env_vars):
     assert expected_description in captured.out
 
 
+def test_list_vaccinations_no_new_vaccinations_prints_message(capsys):
+    """Show message when there are no NEW vaccinations to process"""
+
+    mock_session_cm = MagicMock()
+    mock_calendar = MagicMock()
+    mock_service = MagicMock()
+    mock_service.get_pending_vaccinations.return_value = []
+
+    with (
+        patch("vetlog_calendar.main.get_session", return_value=mock_session_cm),
+        patch("vetlog_calendar.main.PetRepository.find_by_id", return_value=pet()),
+        patch("vetlog_calendar.main.UserRepository.find_by_id", return_value=owner()),
+    ):
+        main.list_vaccinations(calendar=mock_calendar, service=mock_service, language="en")
+
+    mock_calendar.create_event.assert_not_called()
+    mock_service.update_vaccination_status.assert_not_called()
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "no new vaccinations were found"
+
+
 def test_list_vaccinations_handles_pet_has_owner(capsys):
     """List pending vaccinations"""
 


### PR DESCRIPTION
## Summary
Adds a user-facing message when no new vaccinations are found to process.
Fixes #64 

## Changes
- Added output message: `"no new vaccinations were found"`
- Added unit test coverage for the empty vaccinations case
- Verified existing tests still pass

## Issue
Closes the issue requesting feedback when no NEW vaccinations are available.