### PR TITLE
Add message when no new vaccinations are found

### DIFF
--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -95,6 +95,17 @@ def list_vaccinations(
         pet_repository = PetRepository(session)
         user_repository = UserRepository(session)
         vaccinations = service.get_pending_vaccinations()
+
+        # Print message if no new vaccinations found
+        if not vaccinations:
+            message = (
+                "No se encontraron nuevas vacunaciones"
+                if language == "es"
+                else "No new vaccinations were found"
+            )
+            print(message)
+            return
+
         for vaccination in vaccinations:
             pet = pet_repository.find_by_id(vaccination.pet_id)
 


### PR DESCRIPTION
Fixes #73

## Summary
Adds a user-facing message when no new vaccinations are found to process.

## Changes
- Added output message: 'No new vaccinations were found' (English) / 'No se encontraron nuevas vacunaciones' (Spanish)
- Early return when no pending vaccinations exist

## Issue
Closes #73