### PR TITLE
Skip Google Calendar events for inactive pets

### DIFF
--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -24,6 +24,8 @@ from .shared.calendar import Calendar
 from .shared.config import Settings
 from . import __project__, __version__
 
+EXCLUDED_STATUSES = frozenset({"INACTIVE", "DECEASED"})
+
 
 def print_paths():
     """Print paths"""
@@ -116,7 +118,7 @@ def list_vaccinations(
                 pet=pet, vaccination=vaccination, owner=user, language=language
             )
             event = helper.get_event()
-            if pet.status != "DECEASED":
+            if pet.status not in EXCLUDED_STATUSES:
                 calendar.create_event(event)
             service.update_vaccination_status(vaccination)
             print(event)
@@ -146,10 +148,14 @@ def list_dewormings():
         required_pet_ids = {deworming.pet_id for deworming in required_dewormings}
         for deworming in required_dewormings:
             pet = pet_repo.find_by_id(deworming.pet_id)
+            if pet.status in EXCLUDED_STATUSES:
+                continue
             print(f"Pet: {pet.name}, awaiting deworming")
         possible_dewormings = service.get_pending_dewormings(6)
         for deworming in possible_dewormings:
             pet = pet_repo.find_by_id(deworming.pet_id)
+            if pet.status in EXCLUDED_STATUSES:
+                continue
             if pet.going_out_often and deworming.pet_id not in required_pet_ids:
                 print(f"Pet: {pet.name}, awaiting deworming")
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -270,6 +270,110 @@ def test_list_vaccinations_handles_pet_is_deceased(capsys):
     assert expected_description in captured.out
 
 
+def test_list_vaccinations_handles_pet_is_inactive(capsys):
+    """Skip calendar event creation when pet status is INACTIVE"""
+
+    inactive_pet = Pet(
+        id=1,
+        user_id=1,
+        adopter_id=None,
+        name="Sora",
+        birth_date=datetime(2020, 1, 1, 0, 0, 0),
+        breed_id=1,
+        status="INACTIVE",
+        uuid="pet-uuid",
+    )
+
+    mock_session_cm = MagicMock()
+    mock_calendar = MagicMock()
+    mock_service = MagicMock()
+    vaccination_instance = vaccination()
+    mock_service.get_pending_vaccinations.return_value = [vaccination_instance]
+
+    with (
+        patch("vetlog_calendar.main.get_session", return_value=mock_session_cm),
+        patch(
+            "vetlog_calendar.main.PetRepository.find_by_id", return_value=inactive_pet
+        ),
+        patch("vetlog_calendar.main.UserRepository.find_by_id", return_value=owner()),
+    ):
+        main.list_vaccinations(
+            calendar=mock_calendar, service=mock_service, language="en"
+        )
+
+    mock_calendar.create_event.assert_not_called()
+    mock_service.update_vaccination_status.assert_called_once_with(vaccination_instance)
+    captured = capsys.readouterr()
+    expected_description = "Jose - Vaccination appointment for Sora"
+    assert expected_description in captured.out
+
+
+def test_list_dewormings_skips_inactive_pet(capsys):
+    """Do not produce deworming output for INACTIVE pets"""
+
+    inactive_pet = Pet(
+        id=1,
+        user_id=1,
+        adopter_id=None,
+        name="Sora",
+        birth_date=datetime(2020, 1, 1, 0, 0, 0),
+        breed_id=1,
+        status="INACTIVE",
+        uuid="pet-uuid",
+        going_out_often=True,
+    )
+
+    mock_session_cm = MagicMock()
+
+    with (
+        patch("vetlog_calendar.main.get_session", return_value=mock_session_cm),
+        patch(
+            "vetlog_calendar.main.VaccinationService.get_pending_dewormings",
+            return_value=[deworming()],
+        ),
+        patch(
+            "vetlog_calendar.main.PetRepository.find_by_id", return_value=inactive_pet
+        ),
+    ):
+        main.list_dewormings()
+
+    captured = capsys.readouterr()
+    assert "awaiting deworming" not in captured.out
+
+
+def test_list_dewormings_skips_deceased_pet(capsys):
+    """Do not produce deworming output for DECEASED pets"""
+
+    deceased_pet = Pet(
+        id=1,
+        user_id=1,
+        adopter_id=None,
+        name="Sora",
+        birth_date=datetime(2020, 1, 1, 0, 0, 0),
+        breed_id=1,
+        status="DECEASED",
+        uuid="pet-uuid",
+        going_out_often=True,
+    )
+
+    mock_session_cm = MagicMock()
+
+    with (
+        patch("vetlog_calendar.main.get_session", return_value=mock_session_cm),
+        patch(
+            "vetlog_calendar.main.VaccinationService.get_pending_dewormings",
+            return_value=[deworming()],
+        ),
+        patch(
+            "vetlog_calendar.main.PetRepository.find_by_id", return_value=deceased_pet
+        ),
+    ):
+        main.list_dewormings()
+
+    captured = capsys.readouterr()
+    assert "awaiting deworming" not in captured.out
+
+
 def test_list_pets_prints_pending_vaccinations(capsys):
     """List all owners/adopters with pets waiting for vaccination"""
 


### PR DESCRIPTION
Closes #80 

### What changed

Added `EXCLUDED_STATUSES = frozenset({"INACTIVE", "DECEASED"})` as a single module-level constant and applied it across both entry points in the calendar event pipeline:

- `list_vaccinations()` — no longer sends a Google Calendar event when the pet's status is `INACTIVE` (the existing `DECEASED` exclusion was folded into the same constant)
- `list_dewormings()` — no longer produces output for `INACTIVE` or `DECEASED` pets (referenced in the issue as a participant in the same pipeline)

### Tests added

- `test_list_vaccinations_handles_pet_is_inactive` — verifies calendar event is skipped, vaccination record is still marked as processed (preserving existing behavior)
- `test_list_dewormings_skips_inactive_pet`
- `test_list_dewormings_skips_deceased_pet`

All 13 tests pass.