### PR TITLE
Add list_deworming CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ uv run vaccinations
 
 # Check pending vaccinations and create Google Calendar events in Spanish
 uv run vaccinations --language es
+
+# List pets with pending deworming
+uv run dewormings
 ```
 
 **Test**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ paths = "vetlog_calendar.main:print_paths"
 users = "vetlog_calendar.main:list_users"
 pets = "vetlog_calendar.main:list_pets"
 vaccinations = "vetlog_calendar.main:vaccinations_cli"
+dewormings = "vetlog_calendar.main:list_deworming"
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]

--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -160,6 +160,11 @@ def list_dewormings():
                 print(f"Pet: {pet.name}, awaiting deworming")
 
 
+def list_deworming():
+    """CLI entry point for list_dewormings"""
+    list_dewormings()
+
+
 def version_check():
     """Print version info"""
     print(f"{__project__} version {__version__}")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -452,3 +452,10 @@ def test_prints_pending_dewormings_once_when_also_possible_for_outdoor_pet(capsy
 def test_settings_missing_required_vars(clean_env):
     with pytest.raises(ValidationError):
         Settings(_env_file=None)
+
+
+def test_list_deworming_delegates_to_list_dewormings():
+    """list_deworming() CLI entry point delegates to list_dewormings()"""
+    with patch("vetlog_calendar.main.list_dewormings") as mock:
+        main.list_deworming()
+    mock.assert_called_once()


### PR DESCRIPTION
Closes #67

### What changed

- Added `list_deworming()` in `main.py` as the CLI entry point, delegating to `list_dewormings()`, matches the existing `vaccinations_cli` : `list_vaccinations` pattern and satisfies the AC requiring a method named `list_deworming()` in main.py
- Wired `dewormings = "vetlog_calendar.main:list_deworming"` in `pyproject.toml`
- Added usage instructions to README under the Run section

### Tests added

- `test_list_deworming_delegates_to_list_dewormings` - verifies the CLI entry point calls `list_dewormings()`

All tests passed.
