### PR TITLE
Update deworming vaccination status from NEW to PENDING

### DIFF
--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -173,6 +173,7 @@ def list_dewormings(
                 )
                 event = helper.get_deworming_event()
                 calendar.create_event(event)
+                service.update_vaccination_status(deworming)
                 print(event)
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -423,6 +423,26 @@ def test_prints_pending_dewormings(capsys):
     assert expected_output in captured.out
 
 
+def test_list_dewormings_calls_update_vaccination_status(mock_env_vars):
+    """update_vaccination_status is called after creating a deworming calendar event"""
+    mock_session_cm = MagicMock()
+    mock_calendar = MagicMock()
+    mock_service = MagicMock()
+    deworming_instance = deworming()
+    mock_service.get_pending_dewormings.side_effect = lambda months: (
+        [deworming_instance] if months == 12 else []
+    )
+
+    with (
+        patch("vetlog_calendar.main.get_session", return_value=mock_session_cm),
+        patch("vetlog_calendar.main.PetRepository.find_by_id", return_value=pet()),
+        patch("vetlog_calendar.main.UserRepository.find_by_id", return_value=owner()),
+    ):
+        main.list_dewormings(calendar=mock_calendar, service=mock_service, language="en")
+
+    mock_service.update_vaccination_status.assert_called_once_with(deworming_instance)
+
+
 def test_list_dewormings_no_duplicate_events_when_pet_in_both_lists():
     """No duplicate calendar event when a pet appears in both the 12-month and 6-month required lists"""
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -440,6 +440,7 @@ def test_list_dewormings_calls_update_vaccination_status(mock_env_vars):
     ):
         main.list_dewormings(calendar=mock_calendar, service=mock_service, language="en")
 
+    mock_calendar.create_event.assert_called_once()
     mock_service.update_vaccination_status.assert_called_once_with(deworming_instance)
 
 


### PR DESCRIPTION
Closes #90

### What changed

- Added `service.update_vaccination_status(deworming)` in `list_dewormings()` after `calendar.create_event(event)` — mirrors the existing pattern in `list_vaccinations()` and ensures processed dewormings are flipped from `NEW` to `PENDING` so they are not reprocessed on the next run

### Tests added

- `test_list_dewormings_calls_update_vaccination_status` — verifies `update_vaccination_status` is called with the deworming instance after a calendar event is created

All 15 tests pass.