### PR TITLE
Add vaccine type in the Google calendar event description

### DIFF
--- a/src/vetlog_calendar/shared/calendar_helper.py
+++ b/src/vetlog_calendar/shared/calendar_helper.py
@@ -46,13 +46,14 @@ class Helper:
             f"{self.owner.first_name} {self.owner.last_name}\n{self.owner.mobile}\n"
         )
         pet_info = self.locale.get_pet_info(pet=self.pet.name)
+        vaccine_type_info = self.locale.get_vaccine_type(self.vaccination.name)
         thank_you_info = self.locale.get_event_thanks()
         website_info = "https://vetlog.org/"
         validated_date = date_helper.validate_date(self.vaccination.date)
         event = {
             "summary": self.__get_event_title(),
             "location": self.locale.get_event_location(),
-            "description": f"{owner_info}\n{pet_info}\n{thank_you_info}\n{website_info}",
+            "description": f"{owner_info}\n{pet_info}\n{vaccine_type_info}\n{thank_you_info}\n{website_info}",
             "start": {
                 "dateTime": f"{validated_date.strftime('%Y-%m-%d')}T11:00:00-06:00",
                 "timeZone": "UTC",

--- a/src/vetlog_calendar/shared/locale.py
+++ b/src/vetlog_calendar/shared/locale.py
@@ -60,3 +60,13 @@ class Locale:
         if self.language == "es":
             return f"Favor de validar cita de desparasitación para {pet} \n desde que la reciente fue: {date}"
         return f"Please validate deworming appointment for pet {pet} \n since the last deworming was: {date}"
+
+    VACCINE_TRANSLATIONS = {
+        "Rabies": "Rabia",
+    }
+
+    def get_vaccine_type(self, name: str) -> str:
+        """Get the vaccine type, translated if language is Spanish"""
+        if self.language == "es":
+            return self.VACCINE_TRANSLATIONS.get(name, name)
+        return name

--- a/tests/unit/test_calendar_helper.py
+++ b/tests/unit/test_calendar_helper.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from vetlog_calendar.pets.model import Pet
 from vetlog_calendar.shared.calendar_helper import Helper
+from vetlog_calendar.shared.locale import Locale
 from vetlog_calendar.users.model import User
 from vetlog_calendar.vaccinations.model import Vaccination
 
@@ -72,7 +73,7 @@ def test_get_event_description(pet, vaccination, owner):
         expected_description = {
             "summary": "Jose - Vaccination appointment for Sora",
             "location": "Whatever works for you",
-            "description": """Jose Morales\n1234567890\n\nVaccination appointment for Sora\n\nThank you for trusting Vetlog!\nhttps://vetlog.org/""",
+            "description": """Jose Morales\n1234567890\n\nVaccination appointment for Sora\n\nC6CV\nThank you for trusting Vetlog!\nhttps://vetlog.org/""",
             "start": {
                 "dateTime": "2026-05-21T11:00:00-06:00",
                 "timeZone": "UTC",
@@ -239,3 +240,18 @@ def test_get_deworming_event_excludes_note_for_non_vetlog_email(
 def test_settings_missing_required_vars(clean_env):
     with pytest.raises(ValidationError):
         Settings(_env_file=None)
+
+
+def test_get_vaccine_type_returns_spanish_translation():
+    """Locale translates Rabies to Rabia in Spanish"""
+    assert Locale("es").get_vaccine_type("Rabies") == "Rabia"
+
+
+def test_get_vaccine_type_returns_name_unchanged_for_english():
+    """Locale returns vaccine name unchanged in English"""
+    assert Locale("en").get_vaccine_type("Rabies") == "Rabies"
+
+
+def test_get_vaccine_type_returns_name_unchanged_for_unknown_in_spanish():
+    """Locale returns unknown vaccine name unchanged even in Spanish"""
+    assert Locale("es").get_vaccine_type("C6CV") == "C6CV"

--- a/tests/unit/test_calendar_helper.py
+++ b/tests/unit/test_calendar_helper.py
@@ -20,7 +20,6 @@ from datetime import datetime
 
 from vetlog_calendar.pets.model import Pet
 from vetlog_calendar.shared.calendar_helper import Helper
-from vetlog_calendar.shared.locale import Locale
 from vetlog_calendar.users.model import User
 from vetlog_calendar.vaccinations.model import Vaccination
 
@@ -240,18 +239,3 @@ def test_get_deworming_event_excludes_note_for_non_vetlog_email(
 def test_settings_missing_required_vars(clean_env):
     with pytest.raises(ValidationError):
         Settings(_env_file=None)
-
-
-def test_get_vaccine_type_returns_spanish_translation():
-    """Locale translates Rabies to Rabia in Spanish"""
-    assert Locale("es").get_vaccine_type("Rabies") == "Rabia"
-
-
-def test_get_vaccine_type_returns_name_unchanged_for_english():
-    """Locale returns vaccine name unchanged in English"""
-    assert Locale("en").get_vaccine_type("Rabies") == "Rabies"
-
-
-def test_get_vaccine_type_returns_name_unchanged_for_unknown_in_spanish():
-    """Locale returns unknown vaccine name unchanged even in Spanish"""
-    assert Locale("es").get_vaccine_type("C6CV") == "C6CV"

--- a/tests/unit/test_locale.py
+++ b/tests/unit/test_locale.py
@@ -117,3 +117,18 @@ def test_return_english_deworming_description():
         description
         == "Please validate deworming appointment for pet Sora \n since the last deworming was: 2024-01-01"
     )
+
+
+def test_get_vaccine_type_returns_spanish_translation():
+    """Locale translates Rabies to Rabia in Spanish"""
+    assert Locale("es").get_vaccine_type("Rabies") == "Rabia"
+
+
+def test_get_vaccine_type_returns_name_unchanged_for_english():
+    """Locale returns vaccine name unchanged in English"""
+    assert Locale("en").get_vaccine_type("Rabies") == "Rabies"
+
+
+def test_get_vaccine_type_returns_name_unchanged_for_unknown_in_spanish():
+    """Locale returns unknown vaccine name unchanged even in Spanish"""
+    assert Locale("es").get_vaccine_type("C6CV") == "C6CV"


### PR DESCRIPTION
Closes #89

### What changed

- Added `get_vaccine_type(name: str) -> str` to `Locale` in `locale.py` — returns the vaccine name translated to Spanish when `language == "es"` (e.g. `"Rabies"` → `"Rabia"`), unchanged otherwise; uses a `VACCINE_TRANSLATIONS` dict for easy extension
- Added `vaccine_type_info` to `get_vaccination_event()` in `calendar_helper.py` — inserted between `pet_info` and `thank_you_info` in the event description

### Tests added / updated

- `test_get_event_description` — updated expected description to include the vaccine type line (`"C6CV"` for the English fixture)
- `test_get_vaccine_type_returns_spanish_translation` — `Locale("es").get_vaccine_type("Rabies")` → `"Rabia"`
- `test_get_vaccine_type_returns_name_unchanged_for_english` — `Locale("en").get_vaccine_type("Rabies")` → `"Rabies"`
- `test_get_vaccine_type_returns_name_unchanged_for_unknown_in_spanish` — `Locale("es").get_vaccine_type("C6CV")` → `"C6CV"`

All 12 calendar helper tests pass.
