### PR TITLE
Modify deworming date based on going_out_often flag

### DIFF
--- a/src/vetlog_calendar/shared/calendar_helper.py
+++ b/src/vetlog_calendar/shared/calendar_helper.py
@@ -76,8 +76,9 @@ class Helper:
             f"{self.owner.first_name} {self.owner.last_name}\n{self.owner.mobile}\n"
         )
         validated_date = date_helper.validate_date(self.vaccination.date)
+        last_deworming_date = date_helper.get_last_deworming_date(self.vaccination.date, self.pet.going_out_often)
         description_info = self.locale.get_deworming_description(
-            pet=self.pet.name, date=validated_date.strftime("%Y-%m-%d")
+            pet=self.pet.name, date=last_deworming_date.strftime("%Y-%m-%d")
         )
         thank_you_info = self.locale.get_event_thanks()
         website_info = "https://vetlog.org/"

--- a/src/vetlog_calendar/shared/date_helper.py
+++ b/src/vetlog_calendar/shared/date_helper.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import calendar
 from datetime import datetime, timedelta
 
 
@@ -22,3 +23,16 @@ def validate_date(date: datetime) -> datetime:
             return date + timedelta(days=2)
         case _:
             return date
+
+
+def get_last_deworming_date(vaccination_date: datetime, going_out_often: bool) -> datetime:
+    """Return estimated last deworming date: 6 months before appointment if pet goes out often, else 1 year before"""
+    if going_out_often:
+        month = vaccination_date.month - 6
+        year = vaccination_date.year + (month - 1) // 12
+        month = (month - 1) % 12 + 1
+    else:
+        year = vaccination_date.year - 1
+        month = vaccination_date.month
+    day = min(vaccination_date.day, calendar.monthrange(year, month)[1])
+    return vaccination_date.replace(year=year, month=month, day=day)

--- a/tests/unit/test_calendar_helper.py
+++ b/tests/unit/test_calendar_helper.py
@@ -161,7 +161,7 @@ def test_get_deworming_event_description(pet, vaccination, owner):
         expected_description = {
             "summary": "Jose - Deworming appointment for Sora",
             "location": "Whatever works for you",
-            "description": "Jose Morales\n1234567890\n\nPlease validate deworming appointment for pet Sora \n since the last deworming was: 2026-05-21\nThank you for trusting Vetlog!\nhttps://vetlog.org/",
+            "description": "Jose Morales\n1234567890\n\nPlease validate deworming appointment for pet Sora \n since the last deworming was: 2025-05-21\nThank you for trusting Vetlog!\nhttps://vetlog.org/",
             "start": {
                 "dateTime": "2026-05-21T12:00:00-06:00",
                 "timeZone": "UTC",

--- a/tests/unit/test_date_helper.py
+++ b/tests/unit/test_date_helper.py
@@ -15,7 +15,7 @@
 
 from datetime import datetime
 
-from vetlog_calendar.shared.date_helper import validate_date
+from vetlog_calendar.shared.date_helper import validate_date, get_last_deworming_date
 
 
 def test_move_two_days_if_monday():
@@ -51,3 +51,21 @@ def test_no_move_if_saturday():
 def test_no_move_if_sunday():
     date = datetime(2026, 6, 7)  # Sunday
     assert validate_date(date) == date
+
+
+def test_last_deworming_six_months_when_going_out_often():
+    assert get_last_deworming_date(datetime(2026, 5, 21), going_out_often=True) == datetime(2025, 11, 21)
+
+
+def test_last_deworming_one_year_when_not_going_out_often():
+    assert get_last_deworming_date(datetime(2026, 5, 21), going_out_often=False) == datetime(2025, 5, 21)
+
+
+def test_last_deworming_clamps_to_last_day_of_month_when_going_out_often():
+    # Aug 31 - 6 months = Feb 28 (not Feb 31 which doesn't exist)
+    assert get_last_deworming_date(datetime(2026, 8, 31), going_out_often=True) == datetime(2026, 2, 28)
+
+
+def test_last_deworming_clamps_leap_year_feb29_when_not_going_out_often():
+    # Feb 29 (leap year) - 1 year = Feb 28 (non-leap year)
+    assert get_last_deworming_date(datetime(2024, 2, 29), going_out_often=False) == datetime(2023, 2, 28)


### PR DESCRIPTION
Closes #96

## Summary
- Added `get_last_deworming_date(vaccination_date, going_out_often)` in `date_helper.py` to compute the last deworming date: 6 calendar months before the appointment if `going_out_often` is `True`, 1 year before if `False`
- Used exact calendar month arithmetic (no `timedelta` day approximation) so dates like "6 months" are always precise
- Month-end dates are clamped to the last valid day of the target month (e.g. Aug 31 → Feb 28) to avoid `ValueError`
- Updated `get_deworming_event()` in `calendar_helper.py` to use the new helper for the description date
- Added 4 tests to `test_date_helper.py`: normal cases + 2 edge cases (month-end clamp, leap year)
- Updated `test_get_deworming_event_description` in `test_calendar_helper.py` to reflect the new description date

## Test plan
- [x] `test_last_deworming_six_months_when_going_out_often` - 2026-05-21 → 2025-11-21
- [x] `test_last_deworming_one_year_when_not_going_out_often` - 2026-05-21 → 2025-05-21
- [x] `test_last_deworming_clamps_to_last_day_of_month_when_going_out_often` - 2026-08-31 → 2026-02-28
- [x] `test_last_deworming_clamps_leap_year_feb29_when_not_going_out_often` - 2024-02-29 → 2023-02-28
- [x] `test_get_deworming_event_description` - description shows 2025-05-21 for pet with going_out_often=None
- [x] All tests pass