### PR TITLE
fix: use logging for CLI messages

### DIFF
--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -23,14 +23,17 @@ from .vaccinations.repository import VaccinationRepository, VaccineType
 from .vaccinations.service import VaccinationService
 from .shared.calendar import Calendar
 from .shared.config import Settings
+from .shared.logger import Logger
 from . import __project__, __version__
+
+logger = Logger(__name__)
 
 
 def print_paths():
     """Print paths"""
     settings = Settings()
-    print(f"Token path: {settings.TOKEN_PATH}")
-    print(f"Credentials path: {settings.CREDENTIALS_PATH}")
+    logger.info("Token path: %s", settings.TOKEN_PATH)
+    logger.info("Credentials path: %s", settings.CREDENTIALS_PATH)
 
 
 def list_users():
@@ -55,8 +58,13 @@ def list_users():
                 if pet.adopter_id is not None
                 else user_repo.find_by_id(pet.user_id)
             )
-            print(
-                f"{owner.username} - {owner.first_name} {owner.last_name} - {owner.email} - Pet: {pet.name} - awaiting vaccination"
+            logger.info(
+                "%s - %s %s - %s - Pet: %s - awaiting vaccination",
+                owner.username,
+                owner.first_name,
+                owner.last_name,
+                owner.email,
+                pet.name,
             )
 
 
@@ -80,8 +88,11 @@ def list_pets():
                     if pet.adopter_id is not None
                     else user_repo.find_by_id(pet.user_id)
                 )
-                print(
-                    f"Owner: {owner.first_name} {owner.last_name}, Pet: {pet.name}, awaiting vaccination"
+                logger.info(
+                    "Owner: %s %s, Pet: %s, awaiting vaccination",
+                    owner.first_name,
+                    owner.last_name,
+                    pet.name,
                 )
 
 
@@ -100,7 +111,7 @@ def list_vaccinations(
 
         # If there are no pending vaccinations, print a message and exit
         if not vaccinations:
-            print("no new vaccinations were found")
+            logger.info("no new vaccinations were found")
             return
 
         pet_repository = PetRepository(session)
@@ -123,7 +134,7 @@ def list_vaccinations(
             if vaccination.name == VaccineType.RABIES:
                 service.delete_rabies_vaccinations_for_pet(pet.id)
             service.update_vaccination_status(vaccination)
-            print(event)
+            logger.info(event)
 
 
 def vaccinations_cli():
@@ -153,7 +164,7 @@ def list_dewormings(
         user_repo = UserRepository(session)
         pet_repo = PetRepository(session)
         required_dewormings = service.get_pending_dewormings()
-        print(f"Found {len(required_dewormings)} pending dewormings")
+        logger.info("Found %s pending dewormings", len(required_dewormings))
 
         for deworming in required_dewormings:
             pet = pet_repo.find_by_id(deworming.pet_id)
@@ -168,7 +179,7 @@ def list_dewormings(
             event = helper.get_deworming_event()
             calendar.create_event(event)
             service.update_vaccination_status(deworming)
-            print(event)
+            logger.info(event)
 
 
 def dewormings_cli():
@@ -187,4 +198,4 @@ def dewormings_cli():
 
 def version_check():
     """Print version info"""
-    print(f"{__project__} version {__version__}")
+    logger.info("%s version %s", __project__, __version__)

--- a/src/vetlog_calendar/shared/logger.py
+++ b/src/vetlog_calendar/shared/logger.py
@@ -1,0 +1,33 @@
+#  Copyright 2026 Jose Morales contact@josdem.io
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+
+class Logger:
+    """Configure a reusable INFO logger with the CLI output format."""
+
+    def __init__(self, name):
+        self.log = logging.getLogger(name)
+        self.log.setLevel(logging.INFO)
+        self.formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        self.console_handler = logging.StreamHandler()
+        self.console_handler.setFormatter(self.formatter)
+        if not self.log.handlers:
+            self.log.addHandler(self.console_handler)
+
+    def info(self, message, *args):
+        self.log.info(message, *args)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,35 @@
+#  Copyright 2026 Jose Morales contact@josdem.io
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+from vetlog_calendar.shared.logger import Logger
+
+
+def test_logger_uses_datetime_level_and_message_format():
+    logger = Logger("vetlog_calendar.tests.logger")
+
+    assert logger.log.level == logging.INFO
+    assert logger.console_handler.formatter._fmt == (
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+
+def test_logger_info_logs_message(caplog):
+    logger = Logger("vetlog_calendar.tests.logger_info")
+    caplog.set_level("INFO")
+
+    logger.info("Processed %s events", 3)
+
+    assert "Processed 3 events" in caplog.text

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -89,7 +89,7 @@ def pet():
     )
 
 
-def test_list_users_prints_users_with_pets_pending_vaccinations(caplog):
+def test_list_users_logs_users_with_pets_pending_vaccinations(caplog):
     """List all users with pet with pending vaccinations"""
 
     caplog.set_level("INFO")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -89,9 +89,10 @@ def pet():
     )
 
 
-def test_list_users_prints_users_with_pets_pending_vaccinations(capsys):
+def test_list_users_prints_users_with_pets_pending_vaccinations(caplog):
     """List all users with pet with pending vaccinations"""
 
+    caplog.set_level("INFO")
     mock_session_cm = MagicMock()
 
     with (
@@ -105,15 +106,15 @@ def test_list_users_prints_users_with_pets_pending_vaccinations(capsys):
     ):
         main.list_users()
 
-    captured = capsys.readouterr()
     expected_output = (
         "josdem - Jose Morales - contact@josdem.io - Pet: Sora - awaiting vaccination"
     )
-    assert expected_output in captured.out
+    assert expected_output in caplog.text
 
 
-def test_list_vaccinations(capsys, mock_env_vars):
+def test_list_vaccinations(caplog, mock_env_vars):
     """List pending vaccinations"""
+    caplog.set_level("INFO")
     mock_session_cm = MagicMock()
     mock_calendar = MagicMock()
     mock_service = MagicMock()
@@ -133,14 +134,14 @@ def test_list_vaccinations(capsys, mock_env_vars):
     mock_service.delete_rabies_vaccinations_for_pet.assert_called_once_with(pet().id)
     mock_service.update_vaccination_status.assert_called_once_with(vaccination_instance)
 
-    captured = capsys.readouterr()
     expected_description = "Jose - Vaccination appointment for Sora"
-    assert expected_description in captured.out
+    assert expected_description in caplog.text
 
 
-def test_list_vaccinations_no_new_vaccinations_prints_message(capsys):
+def test_list_vaccinations_no_new_vaccinations_prints_message(caplog):
     """Show message when there are no NEW vaccinations to process"""
 
+    caplog.set_level("INFO")
     mock_session_cm = MagicMock()
     mock_calendar = MagicMock()
     mock_service = MagicMock()
@@ -158,13 +159,13 @@ def test_list_vaccinations_no_new_vaccinations_prints_message(capsys):
     mock_calendar.create_event.assert_not_called()
     mock_service.update_vaccination_status.assert_not_called()
 
-    captured = capsys.readouterr()
-    assert captured.out.strip() == "no new vaccinations were found"
+    assert "no new vaccinations were found" in caplog.text
 
 
-def test_list_vaccinations_handles_pet_has_owner(capsys):
+def test_list_vaccinations_handles_pet_has_owner(caplog):
     """List pending vaccinations"""
 
+    caplog.set_level("INFO")
     mock_session_cm = MagicMock()
     mock_calendar = MagicMock()
 
@@ -180,14 +181,14 @@ def test_list_vaccinations_handles_pet_has_owner(capsys):
         main.list_vaccinations(calendar=mock_calendar, language="en")
 
     mock_calendar.create_event.assert_called_once()
-    captured = capsys.readouterr()
     expected_description = "Jose - Vaccination appointment for Sora"
-    assert expected_description in captured.out
+    assert expected_description in caplog.text
 
 
-def test_list_vaccinations_handles_pet_has_adopter(capsys):
+def test_list_vaccinations_handles_pet_has_adopter(caplog):
     """List pending vaccinations"""
 
+    caplog.set_level("INFO")
     adopter = User(
         id=2,
         username="sofiaD",
@@ -227,9 +228,8 @@ def test_list_vaccinations_handles_pet_has_adopter(capsys):
 
     mock_find_user_by_id.assert_called_with(pet.adopter_id)
     mock_calendar.create_event.assert_called_once()
-    captured = capsys.readouterr()
     expected_description = "Sofia - Vaccination appointment for Sora"
-    assert expected_description in captured.out
+    assert expected_description in caplog.text
 
 
 def test_list_dewormings_processes_inactive_pet():
@@ -304,9 +304,10 @@ def test_list_dewormings_processes_deceased_pet():
     mock_service.update_vaccination_status.assert_called_once_with(deworming_instance)
 
 
-def test_list_pets_prints_pending_vaccinations(capsys):
+def test_list_pets_prints_pending_vaccinations(caplog):
     """List all owners/adopters with pets waiting for vaccination"""
 
+    caplog.set_level("INFO")
     mock_session_cm = MagicMock()
 
     with (
@@ -320,14 +321,14 @@ def test_list_pets_prints_pending_vaccinations(capsys):
     ):
         main.list_pets()
 
-    captured = capsys.readouterr()
     expected_output = "Owner: Jose Morales, Pet: Sora, awaiting vaccination"
-    assert expected_output in captured.out
+    assert expected_output in caplog.text
 
 
-def test_prints_pending_dewormings(capsys):
+def test_prints_pending_dewormings(caplog):
     """List pets with pending dewormings"""
 
+    caplog.set_level("INFO")
     mock_session_cm = MagicMock()
     mock_calendar = MagicMock()
 
@@ -342,9 +343,8 @@ def test_prints_pending_dewormings(capsys):
     ):
         main.list_dewormings(calendar=mock_calendar, language="en")
 
-    captured = capsys.readouterr()
     expected_output = "Jose - Deworming appointment for Sora"
-    assert expected_output in captured.out
+    assert expected_output in caplog.text
 
 
 def test_list_dewormings_calls_update_vaccination_status(mock_env_vars):

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -43,7 +43,8 @@ def test_read_version_falls_back_to_pyproject_when_package_metadata_is_missing(
     assert _read_version() == expected_version
 
 
-def test_version_check_uses_pyproject_version(capsys):
+def test_version_check_uses_pyproject_version(caplog):
+    caplog.set_level("INFO")
     version_check()
 
-    assert capsys.readouterr().out.strip() == f"vetlog-calendar version {__version__}"
+    assert f"vetlog-calendar version {__version__}" in caplog.text


### PR DESCRIPTION
Fixes #104.

This replaces the `print()` calls in `src/vetlog_calendar/main.py` with `logging.info()` calls and configures message-only INFO logging for the CLI output paths.

The affected tests now assert the logged messages with `caplog` instead of reading stdout.

Verification:

```powershell
.\.venv\Scripts\python.exe -m pytest
.\.venv\Scripts\ruff.exe check src tests
git diff --check
```