### PR TITLE
Add surgery event listing and tests

### DIFF
--- a/src/vetlog_calendar/shared/calendar.py
+++ b/src/vetlog_calendar/shared/calendar.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import os.path
+import datetime
 
 from google.oauth2.credentials import Credentials
 from google.auth.transport.requests import Request
@@ -52,3 +53,63 @@ class Calendar:
 
         except HttpError as error:
             print(f"An error occurred: {error}")
+
+    def list_surgeries(self):
+        print("Listing surgeries from the previous 7 days")
+        settings = Settings()
+        token_path = settings.TOKEN_PATH
+        credentials_path = settings.CREDENTIALS_PATH
+        creds = None
+
+        if os.path.exists(token_path):
+            creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+
+        if not creds or not creds.valid:
+            print("No valid credentials")
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    credentials_path, SCOPES
+                )
+                creds = flow.run_local_server(port=0)
+
+            with open(token_path, "w") as token:
+                token.write(creds.to_json())
+
+        try:
+            service = build("calendar", "v3", credentials=creds)
+
+            now = datetime.datetime.now(datetime.UTC)
+            seven_days_ago = now - datetime.timedelta(days=7)
+
+            events_result = (
+                service.events()
+                .list(
+                    calendarId="primary",
+                    timeMin=seven_days_ago.isoformat(),
+                    timeMax=now.isoformat(),
+                    singleEvents=True,
+                    orderBy="startTime",
+                )
+                .execute()
+            )
+
+            events = events_result.get("items", [])
+
+            surgeries = [
+                event
+                for event in events
+                if self._is_surgery(event.get("summary", ""))
+            ]
+
+            for event in surgeries:
+                start = event["start"].get("dateTime", event["start"].get("date"))
+                print(start, event["summary"])
+
+        except HttpError as error:
+            print(f"An error occurred: {error}")
+
+    def _is_surgery(self, title: str) -> bool:
+        title = title.lower()
+        return "surgery" in title or "cirugia" in title or "cirugía" in title

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -148,3 +148,76 @@ def test_create_event_handles_http_error(event, capsys):
 
     captured = capsys.readouterr()
     assert "An error occurred" in captured.out
+
+def test_is_surgery_detects_english_surgery():
+    """Detect surgery events in English"""
+    assert Calendar()._is_surgery("Jose - Surgery appointment for Sora")
+
+
+def test_is_surgery_detects_spanish_cirugia():
+    """Detect surgery events in Spanish without accent"""
+    assert Calendar()._is_surgery("Jose - Cirugia appointment for Sora")
+
+
+def test_is_surgery_detects_spanish_cirugia_with_accent():
+    """Detect surgery events in Spanish with accent"""
+    assert Calendar()._is_surgery("Jose - Cirugía appointment for Sora")
+
+
+def test_is_surgery_ignores_non_surgery_event():
+    """Ignore events that are not surgeries"""
+    assert not Calendar()._is_surgery("Jose - Vaccination appointment for Sora")
+
+
+def test_list_surgeries_with_valid_credentials(capsys):
+    """List surgery events from the previous 7 days"""
+    mock_creds = MagicMock()
+    mock_creds.valid = True
+
+    mock_service = MagicMock()
+    mock_events = mock_service.events.return_value
+    mock_list = mock_events.list
+    mock_list.return_value.execute.return_value = {
+        "items": [
+            {
+                "summary": "Jose - Surgery appointment for Sora",
+                "start": {"dateTime": "2026-06-01T11:00:00-06:00"},
+            },
+            {
+                "summary": "Jose - Cita de Cirugia para Luna",
+                "start": {"dateTime": "2026-06-02T11:00:00-06:00"},
+            },
+            {
+                "summary": "Jose - Vaccination appointment for Milo",
+                "start": {"dateTime": "2026-06-03T11:00:00-06:00"},
+            },
+        ]
+    }
+
+    with (
+        patch("vetlog_calendar.shared.calendar.Settings") as mock_settings_cls,
+        patch("vetlog_calendar.shared.calendar.os.path.exists", return_value=True),
+        patch(
+            "vetlog_calendar.shared.calendar.Credentials.from_authorized_user_file",
+            return_value=mock_creds,
+        ),
+        patch("vetlog_calendar.shared.calendar.build", return_value=mock_service),
+    ):
+        mock_settings_cls.return_value.TOKEN_PATH = "/tmp/token.json"
+        mock_settings_cls.return_value.CREDENTIALS_PATH = "/tmp/credentials.json"
+
+        Calendar().list_surgeries()
+
+    captured = capsys.readouterr()
+
+    assert "Jose - Surgery appointment for Sora" in captured.out
+    assert "Jose - Cita de Cirugia para Luna" in captured.out
+    assert "Jose - Vaccination appointment for Milo" not in captured.out
+
+    mock_list.assert_called_once()   
+    call_kwargs = mock_list.call_args.kwargs
+    assert call_kwargs["calendarId"] == "primary"
+    assert call_kwargs["singleEvents"] is True
+    assert call_kwargs["orderBy"] == "startTime"
+    assert "timeMin" in call_kwargs
+    assert "timeMax" in call_kwargs


### PR DESCRIPTION
## Summary

* Added `Calendar.list_surgeries()` to list surgery events from the previous 7 days
* Detects surgery events by checking event titles for `Surgery`, `Cirugia`, or `Cirugía`
* Added unit tests for surgery detection and listing surgery events
* Corrected the line with Cirugia so it would be all in Spanish in the test. If this was not the intent, please disregard. 

## Tests

* `uv run pytest tests/unit -v`

Closes #110
