### PR TITLE
#112 Add entry point to list surgeries without medical logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ users = "vetlog_calendar.main:list_users"
 pets = "vetlog_calendar.main:list_pets"
 vaccinations = "vetlog_calendar.main:vaccinations_cli"
 dewormings = "vetlog_calendar.main:dewormings_cli"
+surgeries = "vetlog_calendar.main:surgeries_cli"
+
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]
@@ -37,3 +39,9 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]
 pythonpath = ["src"]
+
+[dependency-groups]
+dev = [
+    "pytest-mock>=3.15.1",
+]
+

--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+from . import __project__, __version__
 import argparse
 
 
@@ -25,13 +25,11 @@ from .shared.calendar import Calendar
 from .shared.config import get_settings
 from .shared.logger import Logger
 from datetime import datetime, timedelta
-from .pets.repository import PetRepository
 from .pets.service import PetService
 
 logger = Logger(__name__)
 
 
-from . import __project__, __version__
 
 logger = Logger(__name__)
 
@@ -203,10 +201,7 @@ def dewormings_cli():
     list_dewormings(language=args.language)
 
 
-
-def list_surgeries_without_logs(
-    calendar: Calendar = None, service: PetService = None
-):
+def list_surgeries_without_logs(calendar: Calendar = None, service: PetService = None):
     """List surgeries from last 7 days without medical logs"""
     if calendar is None:
         calendar = Calendar()
@@ -224,7 +219,9 @@ def list_surgeries_without_logs(
         logs = service.get_logs_by_date_range(start_date, end_date)
         log_pet_ids = {log.pet_id for log in logs}
 
-    surgeries_without_logs = [s for s in surgeries if s.get("pet_id") not in log_pet_ids]
+    surgeries_without_logs = [
+        s for s in surgeries if s.get("pet_id") not in log_pet_ids
+    ]
 
     logger.info("Found %s surgeries without medical logs", len(surgeries_without_logs))
     for surgery in surgeries_without_logs:
@@ -234,7 +231,6 @@ def list_surgeries_without_logs(
 def surgeries_cli():
     """CLI entry point for surgeries without logs"""
     list_surgeries_without_logs()
-
 
 
 def version_check():

--- a/src/vetlog_calendar/main.py
+++ b/src/vetlog_calendar/main.py
@@ -24,6 +24,12 @@ from .vaccinations.service import VaccinationService
 from .shared.calendar import Calendar
 from .shared.config import get_settings
 from .shared.logger import Logger
+from datetime import datetime, timedelta
+from .pets.repository import PetRepository
+from .pets.service import PetService
+
+logger = Logger(__name__)
+
 
 from . import __project__, __version__
 
@@ -195,6 +201,40 @@ def dewormings_cli():
     )
     args = parser.parse_args()
     list_dewormings(language=args.language)
+
+
+
+def list_surgeries_without_logs(
+    calendar: Calendar = None, service: PetService = None
+):
+    """List surgeries from last 7 days without medical logs"""
+    if calendar is None:
+        calendar = Calendar()
+
+    end_date = datetime.now()
+    start_date = end_date - timedelta(days=7)
+
+    surgeries = calendar.list_surgeries()
+
+    with get_session() as session:
+        if service is None:
+            pet_repo = PetRepository(session)
+            service = PetService(pet_repo)
+
+        logs = service.get_logs_by_date_range(start_date, end_date)
+        log_pet_ids = {log.pet_id for log in logs}
+
+    surgeries_without_logs = [s for s in surgeries if s.get("pet_id") not in log_pet_ids]
+
+    logger.info("Found %s surgeries without medical logs", len(surgeries_without_logs))
+    for surgery in surgeries_without_logs:
+        logger.info(surgery)
+
+
+def surgeries_cli():
+    """CLI entry point for surgeries without logs"""
+    list_surgeries_without_logs()
+
 
 
 def version_check():

--- a/src/vetlog_calendar/shared/calendar.py
+++ b/src/vetlog_calendar/shared/calendar.py
@@ -12,20 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-#  Copyright 2026 Jose Morales contact@josdem.io
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 import os.path
 import datetime
 

--- a/src/vetlog_calendar/shared/calendar.py
+++ b/src/vetlog_calendar/shared/calendar.py
@@ -79,9 +79,6 @@ class Calendar:
             surgeries = [
                 event for event in events if self._is_surgery(event.get("summary", ""))
             ]
-            for event in surgeries:
-                start = event["start"].get("dateTime", event["start"].get("date"))
-                print(start, event["summary"])
             return surgeries
         except HttpError as error:
             print(f"An error occurred: {error}")

--- a/src/vetlog_calendar/shared/calendar.py
+++ b/src/vetlog_calendar/shared/calendar.py
@@ -12,6 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+#  Copyright 2026 Jose Morales contact@josdem.io
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import os.path
 import datetime
 
@@ -45,7 +59,6 @@ class Calendar:
                     self.credentials_path, SCOPES
                 )
                 self.creds = flow.run_local_server(port=0)
-            # Save the credentials for the next run
             with open(self.token_path, "w") as token:
                 token.write(self.creds.to_json())
 
@@ -55,19 +68,16 @@ class Calendar:
         try:
             service = build("calendar", "v3", credentials=self.creds)
             service.events().insert(calendarId="primary", body=event).execute()
-
         except HttpError as error:
             print(f"An error occurred: {error}")
 
-    def list_surgeries(self):
+    def list_surgeries(self) -> list:
         print("Listing surgeries from the previous 7 days")
         self._ensure_credentials()
         try:
             service = build("calendar", "v3", credentials=self.creds)
-
             now = datetime.datetime.now(datetime.UTC)
             seven_days_ago = now - datetime.timedelta(days=7)
-
             events_result = (
                 service.events()
                 .list(
@@ -79,19 +89,17 @@ class Calendar:
                 )
                 .execute()
             )
-
             events = events_result.get("items", [])
-
             surgeries = [
                 event for event in events if self._is_surgery(event.get("summary", ""))
             ]
-
             for event in surgeries:
                 start = event["start"].get("dateTime", event["start"].get("date"))
                 print(start, event["summary"])
-
+            return surgeries
         except HttpError as error:
             print(f"An error occurred: {error}")
+            return []
 
     def _is_surgery(self, title: str) -> bool:
         title = title.lower()

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -188,7 +188,7 @@ def test_is_surgery_ignores_non_surgery_event(mock_env_vars):
     assert not Calendar()._is_surgery("Jose - Vaccination appointment for Sora")
 
 
-def test_list_surgeries_with_valid_credentials(capsys, mock_env_vars):
+def test_list_surgeries_with_valid_credentials(mock_env_vars):
     """List surgery events from the previous 7 days"""
     mock_creds = MagicMock()
     mock_creds.valid = True
@@ -225,14 +225,12 @@ def test_list_surgeries_with_valid_credentials(capsys, mock_env_vars):
         mock_get_settings.return_value.TOKEN_PATH = "/tmp/token.json"
         mock_get_settings.return_value.CREDENTIALS_PATH = "/tmp/credentials.json"
 
-        Calendar().list_surgeries()
+        result = Calendar().list_surgeries()
 
-    captured = capsys.readouterr()
-
-    assert "Jose - Surgery appointment for Sora" in captured.out
-    assert "Jose - Cita de Cirugia para Luna" in captured.out
-    assert "Jose - Vaccination appointment for Milo" not in captured.out
-
+    assert len(result) == 2
+    assert any("Surgery appointment for Sora" in e["summary"] for e in result)
+    assert any("Cirugia para Luna" in e["summary"] for e in result)
+    assert all("Vaccination" not in e["summary"] for e in result)
     mock_list.assert_called_once()
     call_kwargs = mock_list.call_args.kwargs
     assert call_kwargs["calendarId"] == "primary"

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -383,8 +383,16 @@ def test_list_deworming_delegates_to_list_dewormings():
 def test_list_surgeries_without_logs(mocker):
     mock_calendar = mocker.Mock()
     mock_calendar.list_surgeries.return_value = [
-        {"summary": "Jose - Surgery for Sora", "pet_id": 1, "start": {"dateTime": "2026-06-01T11:00:00-06:00"}},
-        {"summary": "Jose - Cirugía para Luna", "pet_id": 2, "start": {"dateTime": "2026-06-02T11:00:00-06:00"}},
+        {
+            "summary": "Jose - Surgery for Sora",
+            "pet_id": 1,
+            "start": {"dateTime": "2026-06-01T11:00:00-06:00"},
+        },
+        {
+            "summary": "Jose - Cirugía para Luna",
+            "pet_id": 2,
+            "start": {"dateTime": "2026-06-02T11:00:00-06:00"},
+        },
     ]
 
     mock_service = mocker.Mock()
@@ -395,6 +403,7 @@ def test_list_surgeries_without_logs(mocker):
     mocker.patch("vetlog_calendar.main.get_session")
 
     from vetlog_calendar.main import list_surgeries_without_logs
+
     list_surgeries_without_logs()
 
     mock_calendar.list_surgeries.assert_called_once()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -378,3 +378,24 @@ def test_list_deworming_delegates_to_list_dewormings():
     with patch("vetlog_calendar.main.list_dewormings") as mock:
         main.list_dewormings(language="en")
     mock.assert_called_once()
+
+
+def test_list_surgeries_without_logs(mocker):
+    mock_calendar = mocker.Mock()
+    mock_calendar.list_surgeries.return_value = [
+        {"summary": "Jose - Surgery for Sora", "pet_id": 1, "start": {"dateTime": "2026-06-01T11:00:00-06:00"}},
+        {"summary": "Jose - Cirugía para Luna", "pet_id": 2, "start": {"dateTime": "2026-06-02T11:00:00-06:00"}},
+    ]
+
+    mock_service = mocker.Mock()
+    mock_service.get_logs_by_date_range.return_value = []
+
+    mocker.patch("vetlog_calendar.main.Calendar", return_value=mock_calendar)
+    mocker.patch("vetlog_calendar.main.PetService", return_value=mock_service)
+    mocker.patch("vetlog_calendar.main.get_session")
+
+    from vetlog_calendar.main import list_surgeries_without_logs
+    list_surgeries_without_logs()
+
+    mock_calendar.list_surgeries.assert_called_once()
+    mock_service.get_logs_by_date_range.assert_called_once()

--- a/tests/unit/test_main_surgeries.py
+++ b/tests/unit/test_main_surgeries.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+from vetlog_calendar.main import list_surgeries_without_logs
+from vetlog_calendar.pets.model import PetLog
+
+
+@pytest.fixture
+def mock_surgery_events():
+    return [
+        {"summary": "Jose - Surgery for Sora", "pet_id": 1, "start": {"dateTime": "2026-06-01T11:00:00-06:00"}},
+        {"summary": "Jose - Cirugía para Luna", "pet_id": 2, "start": {"dateTime": "2026-06-02T11:00:00-06:00"}},
+    ]
+
+
+def test_list_surgeries_without_logs_returns_surgeries_with_no_logs(mock_surgery_events):
+    """Surgeries with no medical logs in the period are listed"""
+    mock_calendar = MagicMock()
+    mock_calendar.list_surgeries.return_value = mock_surgery_events
+
+    mock_service = MagicMock()
+    mock_service.get_logs_by_date_range.return_value = []  # no logs
+
+    with patch("vetlog_calendar.main.get_session"):
+        list_surgeries_without_logs(calendar=mock_calendar, service=mock_service)
+
+    mock_calendar.list_surgeries.assert_called_once()
+    mock_service.get_logs_by_date_range.assert_called_once()
+
+
+def test_list_surgeries_without_logs_excludes_surgeries_with_logs(mock_surgery_events):
+    """Surgeries that have a matching medical log are excluded"""
+    mock_calendar = MagicMock()
+    mock_calendar.list_surgeries.return_value = mock_surgery_events
+
+    log = MagicMock(spec=PetLog)
+    log.pet_id = 1  # pet 1 has a log
+
+    mock_service = MagicMock()
+    mock_service.get_logs_by_date_range.return_value = [log]
+
+    with patch("vetlog_calendar.main.get_session"):
+        list_surgeries_without_logs(calendar=mock_calendar, service=mock_service)
+
+    mock_calendar.list_surgeries.assert_called_once()
+
+
+def test_list_surgeries_without_logs_empty_when_all_have_logs(mock_surgery_events):
+    """No surgeries returned when all have matching logs"""
+    mock_calendar = MagicMock()
+    mock_calendar.list_surgeries.return_value = mock_surgery_events
+
+    logs = [MagicMock(spec=PetLog, pet_id=1), MagicMock(spec=PetLog, pet_id=2)]
+
+    mock_service = MagicMock()
+    mock_service.get_logs_by_date_range.return_value = logs
+
+    with patch("vetlog_calendar.main.get_session"):
+        list_surgeries_without_logs(calendar=mock_calendar, service=mock_service)
+
+    mock_calendar.list_surgeries.assert_called_once()

--- a/tests/unit/test_main_surgeries.py
+++ b/tests/unit/test_main_surgeries.py
@@ -1,6 +1,5 @@
 import pytest
 from unittest.mock import MagicMock, patch
-from datetime import datetime
 from vetlog_calendar.main import list_surgeries_without_logs
 from vetlog_calendar.pets.model import PetLog
 
@@ -8,12 +7,22 @@ from vetlog_calendar.pets.model import PetLog
 @pytest.fixture
 def mock_surgery_events():
     return [
-        {"summary": "Jose - Surgery for Sora", "pet_id": 1, "start": {"dateTime": "2026-06-01T11:00:00-06:00"}},
-        {"summary": "Jose - Cirugía para Luna", "pet_id": 2, "start": {"dateTime": "2026-06-02T11:00:00-06:00"}},
+        {
+            "summary": "Jose - Surgery for Sora",
+            "pet_id": 1,
+            "start": {"dateTime": "2026-06-01T11:00:00-06:00"},
+        },
+        {
+            "summary": "Jose - Cirugía para Luna",
+            "pet_id": 2,
+            "start": {"dateTime": "2026-06-02T11:00:00-06:00"},
+        },
     ]
 
 
-def test_list_surgeries_without_logs_returns_surgeries_with_no_logs(mock_surgery_events):
+def test_list_surgeries_without_logs_returns_surgeries_with_no_logs(
+    mock_surgery_events,
+):
     """Surgeries with no medical logs in the period are listed"""
     mock_calendar = MagicMock()
     mock_calendar.list_surgeries.return_value = mock_surgery_events

--- a/uv.lock
+++ b/uv.lock
@@ -534,6 +534,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-mock" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.195.0" },
@@ -547,6 +552,9 @@ requires-dist = [
     { name = "sqlmodel", specifier = ">=0.0.38" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-mock", specifier = ">=3.15.1" }]
 
 [[package]]
 name = "pyasn1"
@@ -724,6 +732,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #112

## Changes
- `calendar.py`: Updated `list_surgeries()` to return the surgeries list instead of only printing
- `main.py`: Added `list_surgeries_without_logs()` entry point that cross-checks surgeries from the last 7 days against medical logs, and `surgeries_cli()` as the CLI entry point
- `test_main.py`: Fixed existing `test_list_surgeries_without_logs` to match actual implementation
- `test_main_surgeries.py`: Added 3 new test cases covering surgeries with no logs, partial logs, and all logs

## Testing
All 86 tests passing