### PR TITLE
Add datetime formatting helper

### DIFF
--- a/src/vetlog_calendar/shared/date_helper.py
+++ b/src/vetlog_calendar/shared/date_helper.py
@@ -42,3 +42,11 @@ def format_date(date_string: str) -> str:
         return date_string.strftime("%Y-%m-%d")
     parsed = datetime.fromisoformat(date_string)
     return parsed.strftime("%Y-%m-%d")
+
+
+def format_datetime(date_string: str) -> str:
+    """Format a datetime string from YYYY-mm-ddThh:mm:ss:timeZone to YYYY-mm-dd HH:mm"""
+    if isinstance(date_string, datetime):
+        return date_string.strftime("%Y-%m-%d %H:%M")
+    parsed = datetime.fromisoformat(date_string)
+    return parsed.strftime("%Y-%m-%d %H:%M")

--- a/tests/unit/test_date_helper.py
+++ b/tests/unit/test_date_helper.py
@@ -19,6 +19,7 @@ from vetlog_calendar.shared.date_helper import (
     validate_date,
     get_last_deworming_date,
     format_date,
+    format_datetime,
 )
 
 
@@ -109,3 +110,23 @@ def test_format_date_without_timezone():
 
 def test_format_if_date_object():
     assert format_date(datetime(2026, 6, 1, 14, 30)) == "2026-06-01"
+
+
+def test_format_datetime_removes_seconds_and_timezone():
+    assert format_datetime("2026-06-01T14:30:00-05:00") == "2026-06-01 14:30"
+
+
+def test_format_datetime_with_utc_timezone():
+    assert format_datetime("2026-12-25T00:05:30+00:00") == "2026-12-25 00:05"
+
+
+def test_format_datetime_with_positive_offset():
+    assert format_datetime("2026-01-15T23:59:59+05:30") == "2026-01-15 23:59"
+
+
+def test_format_datetime_without_timezone():
+    assert format_datetime("2026-07-04T12:08:45") == "2026-07-04 12:08"
+
+
+def test_format_datetime_if_date_object():
+    assert format_datetime(datetime(2026, 6, 1, 14, 30)) == "2026-06-01 14:30"


### PR DESCRIPTION
Fixes #143.

## What changed

- Added `format_datetime()` to format ISO datetime strings as `YYYY-mm-dd HH:mm`.
- Added unit coverage for timezone offsets, UTC timestamps, datetimes without timezone data, and `datetime` objects.

## Validation

- `uv run pytest tests/unit/test_date_helper.py -q`
- `uv run ruff check`
- `uv run pytest tests/unit -q`
